### PR TITLE
example: fix metastore config in tiflow master

### DIFF
--- a/examples/_v1alpha1_tiflowcluster.yaml
+++ b/examples/_v1alpha1_tiflowcluster.yaml
@@ -16,13 +16,18 @@ spec:
     config: |
       etcd-endpoints = ["etcd:2379"]
       [framework-metastore-conf]
+        schema = "example_framework"
         endpoints = ["mysql:3306"]
       [framework-metastore-conf.auth]
         user = "root"
         passwd = "123456"
       [business-metastore-conf]
-        store-type = "etcd"
-        endpoints = ["etcd:2379"]
+        schema = "example_business"
+        store-type = "sql"
+        endpoints = ["mysql:3306"]
+      [business-metastore-conf.auth]
+        user = "root"
+        passwd = "123456"
   executor:
     baseImage: chunzhuli/dataflow
     maxFailoverCount: 0

--- a/examples/_v1alpha1_tiflowcluster.yaml
+++ b/examples/_v1alpha1_tiflowcluster.yaml
@@ -23,7 +23,6 @@ spec:
         passwd = "123456"
       [business-metastore-conf]
         schema = "example_business"
-        store-type = "sql"
         endpoints = ["mysql:3306"]
       [business-metastore-conf.auth]
         user = "root"


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow Operator!
-->

### What problem does this PR solve?

<!-- Add corresponding issue link with summary if exists -->

Issue link:

### What is changed and how it works?

if `schema` is not provided in metastore config, the following error will be raised when tiflow master starts.

```go
starting tiflow-master ...
/tiflow master --addr=:10240 --advertise-addr=basic-tiflow-master-0.basic-tiflow-master-peer:10240 --config=/etc/tiflow-master/tiflow-master.toml
Error: framework-metastore-conf: (schema: cannot be blank.).
Usage:
  tiflow master [flags]
```

- Besides tiflow supports to use `MySQL` as backend metastore

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Check List  <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Stability test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility
- [ ] Other side effects:

### Note for reviewer