### PR TITLE
pkg: remove sleep in master/executor start script

### DIFF
--- a/pkg/manager/member/template.go
+++ b/pkg/manager/member/template.go
@@ -67,7 +67,6 @@ ARGS="--name $name \
 "
 
 echo "starting tiflow-master ..."
-sleep $((RANDOM % 10))
 echo "/tiflow master ${ARGS}"
 exec /tiflow master ${ARGS}
 `))
@@ -122,7 +121,6 @@ ARGS="--name $name \
 "
 
 echo "starting tiflow-executor ..."
-sleep $((RANDOM % 10))
 echo "/tiflow executor ${ARGS}"
 exec /tiflow executor ${ARGS}
 `))


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow Operator!
-->

### What problem does this PR solve?

<!-- Add corresponding issue link with summary if exists -->

Issue link:

### What is changed and how it works?

- Remove sleep in master/executor start script, because
  - leader election has builtin random mechanism in tiflow master 
  - sleep in tiflow executor start script is useless.

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Check List  <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Stability test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility
- [ ] Other side effects:

### Note for reviewer
