### PR TITLE
fix: remove pv for dm job

### DIFF
--- a/pkg/manager/member/executor_manager.go
+++ b/pkg/manager/member/executor_manager.go
@@ -356,10 +356,6 @@ func (m *executorMemberManager) getNewExecutorStatefulSet(ctx context.Context, t
 	stsAnnotations := map[string]string{}
 
 	podTemp := m.getNewExecutorPodTemp(tc, cfgMap)
-	pvcTemp, err := m.getNewExecutorPVCTemp(tc)
-	if err != nil {
-		return nil, err
-	}
 
 	updateStrategy := appsv1.StatefulSetUpdateStrategy{}
 	if baseExecutorSpec.StatefulSetUpdateStrategy() == appsv1.OnDeleteStatefulSetStrategyType {
@@ -380,13 +376,12 @@ func (m *executorMemberManager) getNewExecutorStatefulSet(ctx context.Context, t
 			OwnerReferences: []metav1.OwnerReference{controller.GetOwnerRef(tc)},
 		},
 		Spec: appsv1.StatefulSetSpec{
-			Replicas:             pointer.Int32Ptr(tc.ExecutorStsDesiredReplicas()),
-			Selector:             stsLabels.LabelSelector(),
-			Template:             podTemp,
-			VolumeClaimTemplates: pvcTemp,
-			ServiceName:          controller.TiflowExecutorPeerMemberName(tcName),
-			PodManagementPolicy:  baseExecutorSpec.PodManagementPolicy(),
-			UpdateStrategy:       updateStrategy,
+			Replicas:            pointer.Int32Ptr(tc.ExecutorStsDesiredReplicas()),
+			Selector:            stsLabels.LabelSelector(),
+			Template:            podTemp,
+			ServiceName:         controller.TiflowExecutorPeerMemberName(tcName),
+			PodManagementPolicy: baseExecutorSpec.PodManagementPolicy(),
+			UpdateStrategy:      updateStrategy,
 		},
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow Operator!
-->

### What problem does this PR solve?
Persistent volume is not used by DM and there are some problems with the latest eks to create volume by gp2 (ver. 1.24). So I just remove it in case we can't create a tiflowcluster.
<!-- Add corresponding issue link with summary if exists -->

Issue link: #52 

### What is changed and how it works?

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Check List  <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [ ] Stability test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility
- [ ] Other side effects:

### Note for reviewer
