### PR TITLE
add hostnetwork support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.16
 
 .PHONY: e2e-test
 e2e-test: E2E_TEST_PACKAGES = ./e2e

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -235,6 +235,7 @@ func (a *componentAccessorImpl) BuildPodSpec() corev1.PodSpec {
 		TopologySpreadConstraints: a.TopologySpreadConstraints(),
 		DNSPolicy:                 a.DnsPolicy(),
 		DNSConfig:                 a.DNSConfig(),
+		HostNetwork:               a.HostNetwork(),
 	}
 	if a.PriorityClassName() != nil {
 		spec.PriorityClassName = *a.PriorityClassName()


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow Operator!
-->

### What problem does this PR solve?

when we set Master's HostNetwork on TiflowCluster CR. The corresponding field on the sts is not set.

Issue link:

### What is changed and how it works?

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Check List  <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] E2E test
- [ ] Stability test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility
- [ ] Other side effects:

### Note for reviewer
